### PR TITLE
fixed upscaling of qrcodes.

### DIFF
--- a/print.css
+++ b/print.css
@@ -2,6 +2,7 @@ html, body, main, div { margin: 0px !important; padding: 0px !important; width: 
 .screen-only, .drag-target { display: none !important; }
 .page-break { display: block; page-break-before: always; }
 .paperwallet { width: 1010px !important; }
+.paperwallet .qrcode { image-rendering: pixelated; }
 .paperwallet .art .address-qr { left: 43px; }
 .paperwallet .art .privatekey-qr { left: 823px; filter: none !important; -moz-filter: none !important; -webkit-filter: none !important;  }
 .paperwallet .art .identicon { left: 42px; top: 51px; }

--- a/src/css/paperwallets.css
+++ b/src/css/paperwallets.css
@@ -1,6 +1,10 @@
 .standalone.page-break { display: none; }
 .paperwallet, .paperwallet .art { width: 1010px; position: relative; margin: 0px; }
 
+.paperwallet .qrcode {
+    image-rendering: pixelated;
+}
+
 .paperwallet .art .address-qr,
 .paperwallet .art .privatekey-qr,
 .paperwallet .art .share-info-box,


### PR DESCRIPTION
This pull-request fixes the following open issues:
https://github.com/ryepdx/ethaddress.org/issues/27
https://github.com/ryepdx/ethaddress.org/issues/25
https://github.com/ryepdx/ethaddress.org/issues/24

The upscaling of the QR-Codes for printing was such that it smoothed the edges leading to printed QR codes that cannot be scanned. With the css property "image-rendering: pixelated;" the QR-code remains readable also in the print view.