### PR TITLE
Update browserify to v14.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "brfs": "^1.4.1",
-    "browserify": "^11.0.1",
-    "browserify-shim": "^3.8.10",
+    "browserify": "^14.4.0",
+    "browserify-shim": "^3.8.14",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-concat-css": "^2.2.0",


### PR DESCRIPTION
Resolve issue #34 (Not working in recent browser versions):
The issue is caused by the Buffer module which is outdated.
The current Buffer implementation overrides the UInt8Array's splice method with an incompatible implementation causing the public key's buffer not to splice and to stay at a length of 65 instead of 64.
The result is an assertion failure in the call to ethUtil.publicToAddress and the "the public key could not be parsed or is invalid" message described in the opened issue.
Updating Browserify to v14.4.0 (which updates the Buffer module version) resolves the issue.